### PR TITLE
fix(*): Update code sandbox urls

### DIFF
--- a/_template/README.md
+++ b/_template/README.md
@@ -8,7 +8,7 @@ Open this example on [CodeSandbox](https://codesandbox.com):
 
 <!-- TODO: update this link to the path for your example: -->
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/template)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/template)
 
 ## Example
 

--- a/basic/README.md
+++ b/basic/README.md
@@ -33,4 +33,4 @@ npm start
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/basic)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/basic)

--- a/bullmq-task-queue/README.md
+++ b/bullmq-task-queue/README.md
@@ -6,7 +6,7 @@ An example of how to setup [bullmq](https://github.com/taskforcesh/bullmq) with 
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/bullmq-task-queue)
+[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/bullmq-task-queue)
 
 ## Usages
 

--- a/catch-boundary/README.md
+++ b/catch-boundary/README.md
@@ -6,7 +6,7 @@ If you want to handle _expected_ errors, you use a `CatchBoundary` to catch thos
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/catch-boundary)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/catch-boundary)
 
 ## Example
 

--- a/chakra-ui/README.md
+++ b/chakra-ui/README.md
@@ -8,7 +8,7 @@ Please note that when adding Chakra UI to a TypeScript project, a minimum TypeSc
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/chakra-ui)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/chakra-ui)
 
 ## Example
 

--- a/client-only-components/README.md
+++ b/client-only-components/README.md
@@ -14,7 +14,7 @@ Open this example on [CodeSandbox](https://codesandbox.com):
 
 <!-- TODO: update this link to the path for your example: -->
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/client-only-components)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/client-only-components)
 
 ## Example
 

--- a/client-side-validation/README.md
+++ b/client-side-validation/README.md
@@ -8,7 +8,7 @@ No third party library is required.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/client-side-validation)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/client-side-validation)
 
 ## Example
 

--- a/collected-notes/README.md
+++ b/collected-notes/README.md
@@ -6,7 +6,7 @@ Shows how to use the Collected Notes CMS as a Headless CMS to provide content of
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/collected-notes)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/collected-notes)
 
 ## Example
 

--- a/combobox-resource-route/README.md
+++ b/combobox-resource-route/README.md
@@ -6,7 +6,7 @@ This demo illustrates how to integrate Reach UI Combobox with Remix.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/combobox-resource-route)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/combobox-resource-route)
 
 ## Example
 

--- a/dark-mode/README.md
+++ b/dark-mode/README.md
@@ -6,7 +6,7 @@ This example shows how you can add dark mode theming to your app
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/dark-mode)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/dark-mode)
 
 ## Example
 

--- a/dataloader/README.md
+++ b/dataloader/README.md
@@ -11,7 +11,7 @@ Note that in many cases, you can meet the same requirement with Remix's own [use
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/dataloader)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/dataloader)
 
 ## Example
 

--- a/emotion/README.md
+++ b/emotion/README.md
@@ -29,7 +29,7 @@ This example features how to use [emotion](https://emotion.sh/) with Remix.
 
 Open this example on [CodeSandbox](https://codesandbox.io/):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/emotion)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/emotion)
 
 ## Getting Started
 

--- a/file-and-cloudinary-upload/README.md
+++ b/file-and-cloudinary-upload/README.md
@@ -22,7 +22,7 @@ The relevent files are:
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/file-and-cloudinary-upload)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/file-and-cloudinary-upload)
 
 ## Related Links
 

--- a/file-and-s3-upload/README.md
+++ b/file-and-s3-upload/README.md
@@ -26,7 +26,7 @@ Note: in order for the image to be displayed after being uploaded to your S3 buc
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/file-and-s3-upload)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/file-and-s3-upload)
 
 ## Related Links
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -8,7 +8,7 @@ See the screen recording at `./screen_recording.gif` or Open this example on [Co
 
 <!-- TODO: update this link to the path for your example: -->
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/firebase)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/firebase)
 
 ## Example
 

--- a/framer-motion/README.md
+++ b/framer-motion/README.md
@@ -33,4 +33,4 @@ npm start
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/framer-motion)
+[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/framer-motion)

--- a/framer-route-animation/README.md
+++ b/framer-route-animation/README.md
@@ -6,7 +6,7 @@ Animate route transition using Framer Motion `AnimatePresence` API and React Rou
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/framer-route-animation)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/framer-route-animation)
 
 ## Example
 

--- a/gdpr-cookie-consent/README.md
+++ b/gdpr-cookie-consent/README.md
@@ -7,7 +7,7 @@ Till the user doesn't click on the `Accept` button, she will see a banner prompt
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/gdpr-cookie-consent)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/gdpr-cookie-consent)
 
 ## Example
 

--- a/google-analytics/README.md
+++ b/google-analytics/README.md
@@ -6,7 +6,7 @@ In this setup we will setup Google Analytics with Remix.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/google-analytics)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/google-analytics)
 
 ## Example
 

--- a/graphql-api/README.md
+++ b/graphql-api/README.md
@@ -14,7 +14,7 @@ This example demonstrates using the [Fetch API][link-fetch] to query a [GraphQL]
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/graphql-api)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/graphql-api)
 
 ## Example
 

--- a/image-resize/README.md
+++ b/image-resize/README.md
@@ -10,7 +10,7 @@ It requires a Node.js environment because sharp is a "native" package.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/image-resize)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/image-resize)
 
 ## Example
 

--- a/infinite-scrolling/README.md
+++ b/infinite-scrolling/README.md
@@ -6,7 +6,7 @@ This example shows a minimal implementation of infinite scrolling that uses [use
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/infinite-scrolling)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/infinite-scrolling)
 
 ## Example
 

--- a/io-ts-formdata-decoding/README.md
+++ b/io-ts-formdata-decoding/README.md
@@ -6,7 +6,7 @@ This example shows how to utilize [io-ts](https://gcanti.github.io/io-ts/) to de
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/io-ts-formdata-decoding)
+[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/io-ts-formdata-decoding)
 
 ## Example
 

--- a/ioredis/README.md
+++ b/ioredis/README.md
@@ -6,7 +6,7 @@ An example of how to setup [ioredis](https://github.com/luin/ioredis) with Remix
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/ioredis)
+[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/ioredis)
 
 ## Usages
 

--- a/jokes/README.md
+++ b/jokes/README.md
@@ -64,4 +64,4 @@ npm start
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/jokes)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/jokes)

--- a/leaflet/README.md
+++ b/leaflet/README.md
@@ -8,7 +8,7 @@ This is a very basic example of remix app with leaflet map.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/leaflet)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/leaflet)
 
 ## Example
 

--- a/mantine/README.md
+++ b/mantine/README.md
@@ -6,7 +6,7 @@ This example features how to use [mantine](https://github.com/mantinedev/mantine
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/mantine)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/mantine)
 
 ## Example
 

--- a/msw/README.md
+++ b/msw/README.md
@@ -6,7 +6,7 @@ This example demonstrates [MSW's][msw] usage with Remix to mock any HTTP calls f
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/msw)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/msw)
 
 ## Example
 

--- a/multiple-forms/README.md
+++ b/multiple-forms/README.md
@@ -6,7 +6,7 @@ Each route only has one action that handles all forms for that route. To disambi
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/multiple-forms)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/multiple-forms)
 
 ## Example
 

--- a/multiple-params/README.md
+++ b/multiple-params/README.md
@@ -78,4 +78,4 @@ npm start
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/multiple-params)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/multiple-params)

--- a/newsletter-signup/README.md
+++ b/newsletter-signup/README.md
@@ -6,7 +6,7 @@ A fun, accessible newsletter signup form with Remix and ConvertKit.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/newsletter-signup)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/newsletter-signup)
 
 ## Example
 

--- a/nprogress/README.md
+++ b/nprogress/README.md
@@ -6,7 +6,7 @@ Shows how to use NProgress to show a progress bar when doing any client-side nav
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/nprogress)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/nprogress)
 
 ## Example
 

--- a/on-demand-hydration/README.md
+++ b/on-demand-hydration/README.md
@@ -6,7 +6,7 @@ This examples show how you can, not only enable or disable JS statically using t
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/on-demand-hydration)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/on-demand-hydration)
 
 ## Example
 

--- a/outlet-form-rerender/README.md
+++ b/outlet-form-rerender/README.md
@@ -10,7 +10,7 @@ For example, when the form is rendered inside a nested route, changing the route
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/outlet-form-rerender)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/outlet-form-rerender)
 
 ## Example
 

--- a/pathless-routes/README.md
+++ b/pathless-routes/README.md
@@ -6,7 +6,7 @@ A simple example demonstrates the usage of the pathless route to create layout w
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/pathless-routes)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/pathless-routes)
 
 ## Example
 

--- a/quirrel/README.md
+++ b/quirrel/README.md
@@ -6,7 +6,7 @@ This is an example of queuing a job to be run in the background with Quirrel.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/quirrel)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/quirrel)
 
 ## Example
 

--- a/react-spring/README.md
+++ b/react-spring/README.md
@@ -6,7 +6,7 @@ A simple example demonstrating the integration of `react-spring` with Remix.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/react-spring)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/react-spring)
 
 ## Example
 

--- a/remix-auth-auth0/README.md
+++ b/remix-auth-auth0/README.md
@@ -6,7 +6,7 @@ Authentication using Remix Auth with the Auth0Strategy.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/remix-auth-auth0)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/remix-auth-auth0)
 
 ## Example
 

--- a/remix-auth-form/README.md
+++ b/remix-auth-form/README.md
@@ -6,7 +6,7 @@ Authentication using Remix Auth with the FormStrategy.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/remix-auth-form)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/remix-auth-form)
 
 ## Example
 

--- a/remix-auth-github/README.md
+++ b/remix-auth-github/README.md
@@ -6,7 +6,7 @@ Authentication using Remix Auth with the GitHubStrategy.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/remix-auth-github)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/remix-auth-github)
 
 ## Example
 

--- a/remix-auth-supabase-github/README.md
+++ b/remix-auth-supabase-github/README.md
@@ -8,7 +8,7 @@ Authentication using `signIn with oauth provider`.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/remix-auth-supabase-github)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/remix-auth-supabase-github)
 
 ## Setup
 

--- a/remix-auth-supabase/README.md
+++ b/remix-auth-supabase/README.md
@@ -6,7 +6,7 @@ Authentication using Remix Auth with the SupabaseStrategy.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/remix-auth-supabase)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/remix-auth-supabase)
 
 ## Setup
 

--- a/route-modal/README.md
+++ b/route-modal/README.md
@@ -6,7 +6,7 @@ Example of using routes to control visibility of modals.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/route-modal)
+[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/route-modal)
 
 ## Example
 

--- a/routes-gen/README.md
+++ b/routes-gen/README.md
@@ -6,7 +6,7 @@ This example shows to install and run the `routes-gen` script with the Remix dri
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/routes-gen)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/routes-gen)
 
 ## Example
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -6,7 +6,7 @@ If you want to combine the **Web Fundamentals & Modern UX** of Remix together wi
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/rust)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/rust)
 
 ## Example
 

--- a/sass/README.md
+++ b/sass/README.md
@@ -6,7 +6,7 @@ Style your Remix app using [Sass](https://sass-lang.com)
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/sass)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/sass)
 
 ## Example
 

--- a/search-input/README.md
+++ b/search-input/README.md
@@ -33,4 +33,4 @@ npm start
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/search-input)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/search-input)

--- a/session-flash/README.md
+++ b/session-flash/README.md
@@ -6,7 +6,7 @@ You want to display a message after a request made from any component. [`session
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/session-flash)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/session-flash)
 
 ## Example
 

--- a/sharing-loader-data/README.md
+++ b/sharing-loader-data/README.md
@@ -6,7 +6,7 @@ Sometimes you have data loaded in one route and you want to access that data in 
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/sharing-loader-data)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/sharing-loader-data)
 
 ## Example
 

--- a/socket.io/README.md
+++ b/socket.io/README.md
@@ -12,7 +12,7 @@ To run this example, run `npm run start:dev` to start the server and `npm run de
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/socket.io)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/socket.io)
 
 ## Example
 

--- a/stitches/README.md
+++ b/stitches/README.md
@@ -27,7 +27,7 @@ This example features how to use [Stitches](https://stitches.dev/) with Remix.
 
 Open this example on [CodeSandbox](https://codesandbox.io/):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/stitches)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/stitches)
 
 ## Getting Started
 

--- a/stripe-integration/README.md
+++ b/stripe-integration/README.md
@@ -29,7 +29,7 @@ Relevant files:
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/stripe-integration)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/stripe-integration)
 
 ## Related Links
 

--- a/styled-components/README.md
+++ b/styled-components/README.md
@@ -6,7 +6,7 @@ This example features how to use [Styled Components](https://styled-components.c
 
 Open this example on [CodeSandbox](https://codesandbox.io/s/styled-components):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/styled-components)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/styled-components)
 
 ## Example
 

--- a/styletron/README.md
+++ b/styletron/README.md
@@ -6,7 +6,7 @@ This example features how to use [Styletron](https://styletron.org/) with Remix.
 
 Open this example on [CodeSandbox](https://codesandbox.io/s/remix-examples-styletron):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/styletron)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/styletron)
 
 ## Example
 

--- a/supabase-subscription/README.md
+++ b/supabase-subscription/README.md
@@ -38,7 +38,7 @@ SUPABASE_URL="https://{YOUR_INSTANCE_NAME}.supabase.co"
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/supabase-subscription)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/supabase-subscription)
 
 ## Example
 

--- a/tailwindcss/README.md
+++ b/tailwindcss/README.md
@@ -6,7 +6,7 @@ Integrate Remix with tailwindcss.
 
 Open this example on [CodeSandbox](https://codesandbox.io/s/remix-tailwind-2x8pg):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/tailwindcss)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/tailwindcss)
 
 ## Example
 

--- a/tiptap-collab-editing/README.md
+++ b/tiptap-collab-editing/README.md
@@ -16,7 +16,7 @@ app
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/tiptap-collab-editing)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/tiptap-collab-editing)
 
 ## Related Links
 

--- a/toast-message/README.md
+++ b/toast-message/README.md
@@ -6,7 +6,7 @@ A simple example to add toast messages in Remix
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/toast-message)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/toast-message)
 
 ## Example
 

--- a/turborepo-vercel/README.md
+++ b/turborepo-vercel/README.md
@@ -8,7 +8,7 @@ Open this example on [CodeSandbox](https://codesandbox.com):
 
 <!-- TODO: update this link to the path for your example: -->
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/turborepo-vercel)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/turborepo-vercel)
 
 ## Example
 

--- a/twind/README.md
+++ b/twind/README.md
@@ -6,7 +6,7 @@ Integrate Twind with Remix with SSR.
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/twind)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/twind)
 
 ## Example
 

--- a/usematches-loader-data/README.md
+++ b/usematches-loader-data/README.md
@@ -10,7 +10,7 @@ Note: if you have UI state (non-persisted state managed by React) then you'd pro
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/usematches-loader-data)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/usematches-loader-data)
 
 ## Example
 

--- a/vanilla-extract/README.md
+++ b/vanilla-extract/README.md
@@ -6,7 +6,7 @@ Integrate Remix with [vanilla-extract.](https://vanilla-extract.style)
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/vanilla-extract)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/examples/tree/main/vanilla-extract)
 
 ## Example
 


### PR DESCRIPTION
Sice repository change, codesandbox links got broken.

Before: https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/basic
After: https://codesandbox.io/s/github/remix-run/examples/tree/main/basic