### PR TITLE
chore: add Dependabot for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This way we can just merge PRs instead of needing to update ourselves manually