### PR TITLE
fix(framer-route-animation): use `location.pathname` instead of `key`

### DIFF
--- a/framer-route-animation/app/root.tsx
+++ b/framer-route-animation/app/root.tsx
@@ -35,7 +35,7 @@ export default function App() {
         </header>
         <AnimatePresence exitBeforeEnter initial={false}>
           <motion.main
-            key={useLocation().key}
+            key={useLocation().pathname}
             initial={{ x: "10%", opacity: 0 }}
             animate={{ x: "0", opacity: 1 }}
             exit={{ x: "-40%", opacity: 0 }}


### PR DESCRIPTION
Using the key responds to changes in searchParams, which duplicate the animation for pages the signs searchParams in useEffect when first render