### PR TITLE
Fix dataloader implementation

### DIFF
--- a/dataloader/app/loaders/userLoader.ts
+++ b/dataloader/app/loaders/userLoader.ts
@@ -3,12 +3,14 @@ import DataLoader from "dataloader";
 import { db } from "~/data.server";
 
 export const createUsersByIdLoader = () =>
-  new DataLoader(async (keys: Readonly<string[]>) =>
-    db.user.findMany({
+  new DataLoader(async (ids: Readonly<string[]>) => {
+    const users = await db.user.findMany({
       where: {
         id: {
-          in: keys,
+          in: ids,
         },
       },
-    })
-  );
+    });
+    const userMap = new Map(users.map((user) => [user.id, user]));
+    return ids.map((id) => userMap.get(id) ?? null);
+  });

--- a/dataloader/app/routes/users/index.tsx
+++ b/dataloader/app/routes/users/index.tsx
@@ -24,9 +24,12 @@ export const loader: LoaderFunction = async ({ context }) => {
     "2cbad877-2da6-422d-baa6-c6a96a9e085f"
   );
   const user3 = context.loaders.usersById.load(
+    "does_not_exist"
+  );
+  const user4 = context.loaders.usersById.load(
     "1dd9e502-343d-4acb-9391-2bc52d5ea904"
   );
-  const users = await Promise.all([user1, user2, user3]);
+  const users = await Promise.all([user1, user2, user3, user4]);
 
   return json({ users });
 };
@@ -38,8 +41,8 @@ export default function UserEmails() {
     <section>
       <h2>Emails</h2>
       <ul>
-        {users.map((user) => (
-          <li key={user.email}>{user.email}</li>
+        {users.map((user, i) => (
+          <li key={i}>{user ? user.email : 'Not found'}</li>
         ))}
       </ul>
     </section>


### PR DESCRIPTION
The dataloader implementation didn't uphold the following constraints:

```
- The Array of values must be the same length as the Array of keys.
- Each index in the Array of values must correspond to the same index in the Array of keys.
```

https://github.com/graphql/dataloader#batch-function


This meant a call to `context.loaders.usersById.load('does_not_exist')` would result in an invariant thrown in dataloader (see below) and, depending on the underlying data source, a call to `context.loaders.usersById.load('does_exist')` could return some other random user 😬

Before:
<img width="1728" alt="Screenshot 2022-10-03 at 10 40 35" src="https://user-images.githubusercontent.com/539309/193549417-f31b1ce5-7b04-4d07-883e-15cb9682cc57.png">

After:
<img width="1725" alt="Screenshot 2022-10-03 at 10 39 48" src="https://user-images.githubusercontent.com/539309/193549440-c379d937-33c5-4f19-883a-0cddf9af275d.png">