### PR TITLE
feat(msw): update `dev` script to initialize mocks

### DIFF
--- a/msw/package.json
+++ b/msw/package.json
@@ -3,7 +3,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev",
+    "dev": "binode --require ./mocks -- @remix-run/dev:remix dev",
     "start": "remix-serve build"
   },
   "dependencies": {
@@ -18,8 +18,9 @@
     "@remix-run/eslint-config": "*",
     "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.13",
+    "binode": "^1.0.5",
     "eslint": "^8.11.0",
-    "msw": "^0.39.2",
+    "msw": "^0.47.3",
     "typescript": "^4.7.4"
   },
   "engines": {


### PR DESCRIPTION
**What existing problem does the pull request solves**

- Support initialize msw mocks when working in local development.

Fixes #44 

**Special note to reviewers**

- Dev dependency `binode` is added to initialize msw mocks then start `remix dev`.
- Upgrade dev dependency `msw` to `^0.47.3` in order to work with `binode` (Related PR: https://github.com/remix-run/indie-stack/pull/158).