### PR TITLE
fix(vanilla-extract): add `isbot` dependency

### DIFF
--- a/vanilla-extract/package.json
+++ b/vanilla-extract/package.json
@@ -20,6 +20,7 @@
     "@vanilla-extract/css": "^1.9.0",
     "@vanilla-extract/sprinkles": "^1.5.0",
     "clsx": "^1.2.1",
+    "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
I was checking out vanilla extract + remix and noticed that the example did not run unless this dependency was added. Looks like it's used in:

https://github.com/remix-run/examples/blob/main/vanilla-extract/app/entry.server.tsx#L17-L29

