### PR TITLE
fix(emotion): fix render loop

### DIFF
--- a/emotion/app/root.tsx
+++ b/emotion/app/root.tsx
@@ -10,7 +10,7 @@ import {
   ScrollRestoration,
   useCatch,
 } from "@remix-run/react";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useRef } from "react";
 
 import ServerStyleContext from "./styles/server.context";
 import ClientStyleContext from "./styles/client.context";
@@ -35,11 +35,15 @@ const Document = withEmotionCache(
   ({ children, title }: DocumentProps, emotionCache) => {
     const serverStyleData = useContext(ServerStyleContext);
     const clientStyleData = useContext(ClientStyleContext);
+    const reinjectStylesRef = useRef(true);
 
     // Only executed on client
     // When a top level ErrorBoundary or CatchBoundary are rendered,
     // the document head gets removed, so we have to create the style tags
     useEffect(() => {
+      if (!reinjectStylesRef.current) {
+        return;
+      }
       // re-link sheet container
       emotionCache.sheet.container = document.head;
 
@@ -52,9 +56,9 @@ const Document = withEmotionCache(
 
       // reset cache to re-apply global styles
       clientStyleData.reset();
-      // We only want to do this on mount, not when styles change
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+      // ensure we only do this once per mount
+      reinjectStylesRef.current = false;
+    }, [clientStyleData, emotionCache.sheet]);
 
     return (
       <html lang="en">

--- a/emotion/app/root.tsx
+++ b/emotion/app/root.tsx
@@ -37,6 +37,8 @@ const Document = withEmotionCache(
     const clientStyleData = useContext(ClientStyleContext);
 
     // Only executed on client
+    // When a top level ErrorBoundary or CatchBoundary are rendered,
+    // the document head gets removed, so we have to create the style tags
     useEffect(() => {
       // re-link sheet container
       emotionCache.sheet.container = document.head;
@@ -50,7 +52,8 @@ const Document = withEmotionCache(
 
       // reset cache to re-apply global styles
       clientStyleData.reset();
-    }, [clientStyleData, emotionCache.sheet]);
+      // We only want to do this on mount, not when styles change
+    }, []);
 
     return (
       <html lang="en">

--- a/emotion/app/root.tsx
+++ b/emotion/app/root.tsx
@@ -53,6 +53,7 @@ const Document = withEmotionCache(
       // reset cache to re-apply global styles
       clientStyleData.reset();
       // We only want to do this on mount, not when styles change
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return (


### PR DESCRIPTION
This solves the render loop when loading the emotion example. As far as I can see, we only need to re-inject the styles on the client if the top level component gets unmounted (because that removes the document head, where the styles are).

My original PR had removed all of the code related to this re-injection, but we do need it for that case.

Original description below.

~However, when you trigger the catch boundary on the client, you loose all the styles, since the entire document is re-rendered. This same problem exists in the Chakra example, but you can't easily tell, since there is no link you can follow to trigger the error boundary on the client.~

I finally understand what the code I was removed was trying to do (add the styles back in after re-mounting the document), but it was broken.

~I'm not sure what the correct fix is, but I think this is better than the broken example we have now. I will try to spend some more time on this soon, to see if I can find a complete solution.~

Fixes: https://github.com/remix-run/examples/issues/1