### PR TITLE
fix(jokes): throw 403 instead of 401 if the use isn't the owner

### DIFF
--- a/_official-jokes/app/routes/jokes/$jokeId.tsx
+++ b/_official-jokes/app/routes/jokes/$jokeId.tsx
@@ -56,7 +56,7 @@ export const action: ActionFunction = async ({ request, params }) => {
   }
   if (joke.jokesterId !== userId) {
     throw new Response("Pssh, nice try. That's not your joke", {
-      status: 401,
+      status: 403,
     });
   }
   await db.joke.delete({ where: { id: params.jokeId } });
@@ -87,7 +87,7 @@ export function CatchBoundary() {
         </div>
       );
     }
-    case 401: {
+    case 403: {
       return (
         <div className="error-container">
           Sorry, but {params.jokeId} is not your joke.


### PR DESCRIPTION
Just like @chaukhoa97 suggested in https://github.com/remix-run/remix/pull/4688