### PR TITLE
fix: don't return from `startTransition`

### DIFF
--- a/__template/app/entry.client.tsx
+++ b/__template/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/_official-blog-tutorial/app/entry.client.tsx
+++ b/_official-blog-tutorial/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/_official-jokes/app/entry.client.tsx
+++ b/_official-jokes/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/_official-realtime-app/app/entry.client.tsx
+++ b/_official-realtime-app/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/basic/app/entry.client.tsx
+++ b/basic/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/bullmq-task-queue/app/entry.client.tsx
+++ b/bullmq-task-queue/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/catch-boundary/app/entry.client.tsx
+++ b/catch-boundary/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/client-only-components/app/entry.client.tsx
+++ b/client-only-components/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/client-side-validation/app/entry.client.tsx
+++ b/client-side-validation/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/collected-notes/app/entry.client.tsx
+++ b/collected-notes/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/combobox-resource-route/app/entry.client.tsx
+++ b/combobox-resource-route/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/dark-mode/app/entry.client.tsx
+++ b/dark-mode/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/dataloader/app/entry.client.tsx
+++ b/dataloader/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/file-and-cloudinary-upload/app/entry.client.tsx
+++ b/file-and-cloudinary-upload/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/file-and-s3-upload/app/entry.client.tsx
+++ b/file-and-s3-upload/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/firebase/app/entry.client.tsx
+++ b/firebase/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/form-to-notion-db/app/entry.client.tsx
+++ b/form-to-notion-db/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/framer-motion/app/entry.client.tsx
+++ b/framer-motion/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/framer-route-animation/app/entry.client.tsx
+++ b/framer-route-animation/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/gdpr-cookie-consent/app/entry.client.tsx
+++ b/gdpr-cookie-consent/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/google-analytics/app/entry.client.tsx
+++ b/google-analytics/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/graphql-api/app/entry.client.tsx
+++ b/graphql-api/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/image-resize/app/entry.client.tsx
+++ b/image-resize/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/infinite-scrolling/app/entry.client.tsx
+++ b/infinite-scrolling/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/io-ts-formdata-decoding/app/entry.client.tsx
+++ b/io-ts-formdata-decoding/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/ioredis/app/entry.client.tsx
+++ b/ioredis/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/leaflet/app/entry.client.tsx
+++ b/leaflet/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/mantine/app/entry.client.tsx
+++ b/mantine/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/msw/app/entry.client.tsx
+++ b/msw/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/multiple-forms/app/entry.client.tsx
+++ b/multiple-forms/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/multiple-params/app/entry.client.tsx
+++ b/multiple-params/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/newsletter-signup/app/entry.client.tsx
+++ b/newsletter-signup/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/nprogress/app/entry.client.tsx
+++ b/nprogress/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/on-demand-hydration/app/entry.client.tsx
+++ b/on-demand-hydration/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/outlet-form-rerender/app/entry.client.tsx
+++ b/outlet-form-rerender/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/pathless-routes/app/entry.client.tsx
+++ b/pathless-routes/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/playwright/app/entry.client.tsx
+++ b/playwright/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/pm-app/app/entry.client.tsx
+++ b/pm-app/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/quirrel/app/entry.client.tsx
+++ b/quirrel/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/react-spring/app/entry.client.tsx
+++ b/react-spring/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/redis-upstash-session/app/entry.client.tsx
+++ b/redis-upstash-session/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/remix-auth-auth0/app/entry.client.tsx
+++ b/remix-auth-auth0/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/remix-auth-form/app/entry.client.tsx
+++ b/remix-auth-form/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/remix-auth-github/app/entry.client.tsx
+++ b/remix-auth-github/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/remix-auth-supabase-github/app/entry.client.tsx
+++ b/remix-auth-supabase-github/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/remix-auth-supabase/app/entry.client.tsx
+++ b/remix-auth-supabase/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/route-modal/app/entry.client.tsx
+++ b/route-modal/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/routes-gen/app/entry.client.tsx
+++ b/routes-gen/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/rust/app/entry.client.tsx
+++ b/rust/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/sanity/app/entry.client.tsx
+++ b/sanity/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/sass/app/entry.client.tsx
+++ b/sass/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/search-input/app/entry.client.tsx
+++ b/search-input/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/session-flash/app/entry.client.tsx
+++ b/session-flash/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/sharing-loader-data/app/entry.client.tsx
+++ b/sharing-loader-data/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/socket.io/app/entry.client.tsx
+++ b/socket.io/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/strapi/app/entry.client.tsx
+++ b/strapi/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/stripe-integration/app/entry.client.tsx
+++ b/stripe-integration/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/supabase-subscription/app/entry.client.tsx
+++ b/supabase-subscription/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/tailwindcss/app/entry.client.tsx
+++ b/tailwindcss/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/tiptap-collab-editing/app/entry.client.tsx
+++ b/tiptap-collab-editing/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/toast-message/app/entry.client.tsx
+++ b/toast-message/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/turborepo-vercel/apps/remix-app/app/entry.client.tsx
+++ b/turborepo-vercel/apps/remix-app/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/twind/app/entry.client.tsx
+++ b/twind/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/unocss/app/entry.client.tsx
+++ b/unocss/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/usematches-loader-data/app/entry.client.tsx
+++ b/usematches-loader-data/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/vanilla-extract/app/entry.client.tsx
+++ b/vanilla-extract/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/xata/app/entry.client.tsx
+++ b/xata/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);

--- a/yarn-pnp/app/entry.client.tsx
+++ b/yarn-pnp/app/entry.client.tsx
@@ -3,14 +3,14 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 const hydrate = () =>
-  startTransition(() =>
+  startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
         <RemixBrowser />
       </StrictMode>
-    )
-  );
+    );
+  });
 
 if (window.requestIdleCallback) {
   window.requestIdleCallback(hydrate);


### PR DESCRIPTION
types appear to have changed and now `startTransition` wants a return of `void` or `undefined`


```ts
app/entry.client.tsx:7:5 - error TS2322: Type 'Root' is not assignable to type 'VoidOrUndefinedOnly'.

  7     hydrateRoot(
        ~~~~~~~~~~~~
  8       document,
    ~~~~~~~~~~~~~~~
... 
 11       </StrictMode>
    ~~~~~~~~~~~~~~~~~~~
 12     )
    ~~~~~

  node_modules/@types/react/index.d.ts:1107:38
    1107     export type TransitionFunction = () => VoidOrUndefinedOnly;
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~
    The expected type comes from the return type of this signature.


Found 1 error.

error Command failed with exit code 1.
```

Signed-off-by: Logan McAnsh <logan@mcan.sh>
