### PR TITLE
refactor(_official-realtime-app): Fix realtime app revalidation and user avatars

### DIFF
--- a/_official-realtime-app/app/data.tsx
+++ b/_official-realtime-app/app/data.tsx
@@ -13,11 +13,11 @@ export type Issue = {
 const users: Record<string, User> = {
   chance: {
     name: "Chance Strickland",
-    avatarUrl: "http://github.com/chaance.png",
+    avatarUrl: "https://github.com/chaance.png",
   },
   ryan: {
     name: "Ryan Florence",
-    avatarUrl: "http://github.com/ryanflorence.png",
+    avatarUrl: "https://github.com/ryanflorence.png",
   },
 };
 

--- a/_official-realtime-app/app/data.tsx
+++ b/_official-realtime-app/app/data.tsx
@@ -13,13 +13,11 @@ export type Issue = {
 const users: Record<string, User> = {
   chance: {
     name: "Chance Strickland",
-    avatarUrl:
-      "https://pbs.twimg.com/profile_images/1541089143706374144/uoW00Tgv_400x400.jpg",
+    avatarUrl: "http://github.com/chaance.png",
   },
   ryan: {
     name: "Ryan Florence",
-    avatarUrl:
-      "https://pbs.twimg.com/profile_images/1344410501309030403/L2rNpO6h_400x400.jpg",
+    avatarUrl: "http://github.com/ryanflorence.png",
   },
 };
 

--- a/_official-realtime-app/app/root.tsx
+++ b/_official-realtime-app/app/root.tsx
@@ -50,9 +50,3 @@ function useRealtimeIssuesRevalidation() {
     revalidator.revalidate();
   }, [data, revalidator]);
 }
-
-// FIXME: Pointless action for revalidation until:
-// https://github.com/remix-run/remix/issues/4485
-export async function action() {
-  return json({ ok: true });
-}

--- a/_official-realtime-app/app/routes/dev.null.ts
+++ b/_official-realtime-app/app/routes/dev.null.ts
@@ -1,0 +1,7 @@
+import { json } from "@remix-run/node";
+
+// FIXME: Pointless action for revalidation until:
+// https://github.com/remix-run/remix/issues/4485
+export async function action() {
+  return json({ ok: true });
+}


### PR DESCRIPTION
When I did the change in #87 I used useDataRefresh from Remix Utils. This hooks needs the action used to trigger the revalidation to live at `/dev/null` but I forgot to move the action from root to that file, because of this the revalidation is not working.

I also noticed while testing in local that Ryan's avatar was broken, this is because he changed his Twitter avatar, so I changed both avatar URLs to use the GitHub `https://github.com/username.png` format which redirects to the current GitHub avatar.