### PR TITLE
docs(framer-motion-animation): fix broken links

### DIFF
--- a/framer-route-animation/README.md
+++ b/framer-route-animation/README.md
@@ -20,6 +20,6 @@ The `Outlet` component from Remix will always render the currently active route.
 
 ## Related Links
 
-- [useOutlet](https://reactrouter.com/docs/en/v6/hooks/use-outlet)
-- [useLocation](https://reactrouter.com/docs/en/v6/hooks/use-location)
+- [useOutlet](https://reactrouter.com/en/6.5.0/hooks/use-outlet)
+- [useLocation](https://reactrouter.com/en/6.5.0/hooks/use-location)
 - [Framer Motion](https://www.framer.com/docs/introduction/)

--- a/framer-route-animation/README.md
+++ b/framer-route-animation/README.md
@@ -20,6 +20,6 @@ The `Outlet` component from Remix will always render the currently active route.
 
 ## Related Links
 
-- [useOutlet](https://reactrouter.com/en/6.5.0/hooks/use-outlet)
-- [useLocation](https://reactrouter.com/en/6.5.0/hooks/use-location)
+- [useOutlet](https://reactrouter.com/hooks/use-outlet)
+- [useLocation](https://reactrouter.com/hooks/use-location)
 - [Framer Motion](https://www.framer.com/docs/introduction/)


### PR DESCRIPTION
Links to the react router documentation in the framer-route-animation readme were not working.