### PR TITLE
fix(client-only-components): fix ClientOnly children call

### DIFF
--- a/client-only-components/app/routes/index.tsx
+++ b/client-only-components/app/routes/index.tsx
@@ -8,11 +8,11 @@ export default function Screen() {
   return (
     <>
       <ClientOnly fallback={<p>Loading...</p>}>
-        <BrokenOnTheServer />
+        {() => <BrokenOnTheServer />}
       </ClientOnly>
 
       <ClientOnly fallback={<p>Loading...</p>}>
-        <ComplexComponent />
+        {() => <ComplexComponent />}
       </ClientOnly>
 
       <button


### PR DESCRIPTION
`<ClientOnly />` calls its child. 

https://github.com/sergiodxa/remix-utils/blob/main/src/react/client-only.tsx#L30