### PR TITLE
chore(_official-realtime-app,sse-chat,sse-counter): upgrade `remix-utils`

### DIFF
--- a/_official-realtime-app/app/root.tsx
+++ b/_official-realtime-app/app/root.tsx
@@ -5,11 +5,10 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useRevalidator,
 } from "@remix-run/react";
 import { useEffect } from "react";
 import { useEventSource } from "remix-utils";
-
-import { useRevalidator } from "~/use-revalidator";
 
 import icons from "./icons.svg";
 import styles from "./styles.processed.css";
@@ -44,8 +43,8 @@ export default function App() {
 
 function useRealtimeIssuesRevalidation() {
   const data = useEventSource("/issues-events");
-  const revalidator = useRevalidator();
+  const { revalidate } = useRevalidator();
   useEffect(() => {
-    revalidator.revalidate();
-  }, [data, revalidator]);
+    revalidate();
+  }, [data, revalidate]);
 }

--- a/_official-realtime-app/app/routes/dev.null.ts
+++ b/_official-realtime-app/app/routes/dev.null.ts
@@ -1,7 +1,0 @@
-import { json } from "@remix-run/node";
-
-// FIXME: Pointless action for revalidation until:
-// https://github.com/remix-run/remix/issues/4485
-export async function action() {
-  return json({ ok: true });
-}

--- a/_official-realtime-app/app/use-revalidator.tsx
+++ b/_official-realtime-app/app/use-revalidator.tsx
@@ -1,9 +1,0 @@
-import { useMemo } from "react";
-import { useDataRefresh } from "remix-utils";
-
-// FIXME: This is unneeded after https://github.com/remix-run/remix/issues/4485
-export function useRevalidator() {
-  const { refresh } = useDataRefresh();
-
-  return useMemo(() => ({ revalidate: refresh }), [refresh]);
-}

--- a/_official-realtime-app/package.json
+++ b/_official-realtime-app/package.json
@@ -22,7 +22,7 @@
     "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remix-utils": "^4.2.1",
+    "remix-utils": "^6.0.0",
     "tiny-invariant": "^1.3.1"
   },
   "devDependencies": {

--- a/sse-chat/package.json
+++ b/sse-chat/package.json
@@ -13,7 +13,7 @@
     "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remix-utils": "^5.1.0"
+    "remix-utils": "^6.0.0"
   },
   "devDependencies": {
     "@remix-run/dev": "*",

--- a/sse-counter/package.json
+++ b/sse-counter/package.json
@@ -13,7 +13,7 @@
     "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remix-utils": "^5.1.0"
+    "remix-utils": "^6.0.0"
   },
   "devDependencies": {
     "@remix-run/dev": "*",


### PR DESCRIPTION
This upgrade the Remix Utils dependency in the SSE examples (the chat, counter and realtime app).

In the realtime app it also replace the useRevalidator built on top of Remix Utils's useDataRefresh for the now built-in useRevalidator hook and removes the `/dev/null` action required to make useDataRefresh works.