### PR TITLE
fix(_official-blog-tutorial): fix `typecheck` script

### DIFF
--- a/_official-blog-tutorial/package.json
+++ b/_official-blog-tutorial/package.json
@@ -18,7 +18,7 @@
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 'cypress open'",
     "pretest:e2e:run": "npm run build",
     "test:e2e:run": "cross-env PORT=8811 start-server-and-test start:mocks http://localhost:8811 'cypress run'",
-    "typecheck": "tsc && tsc cypress",
+    "typecheck": "tsc && tsc -p cypress",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },
   "prettier": {},


### PR DESCRIPTION
Apparently we need to add the `-p` flag when running `tsc` on the `cypress` folder
- https://github.com/remix-run/indie-stack/actions/runs/3951228293/jobs/6764810424
- https://github.com/remix-run/blues-stack/actions/runs/3951125579/jobs/6764576532
- https://github.com/remix-run/grunge-stack/actions/runs/3951229138/jobs/6764812112