### PR TITLE
fix(firebase): fix several things

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -18,7 +18,7 @@
       "port": 5001
     },
     "hosting": {
-      "port": 5000
+      "port": 5002
     },
     "auth": {
       "port": 9099

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -30,6 +30,6 @@
     "typescript": "^4.8.4"
   },
   "engines": {
-    "node": "14"
+    "node": "16"
   }
 }

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -10,19 +10,19 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/node": "1.5.1",
-    "@remix-run/react": "1.5.1",
-    "@remix-run/serve": "1.5.1",
+    "@remix-run/node": "*",
+    "@remix-run/react": "*",
+    "@remix-run/serve": "*",
     "firebase-admin": "^10.0.2",
     "firebase-functions": "^3.21.2",
     "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remix-google-cloud-functions": "0.0.1"
+    "remix-google-cloud-functions": "0.0.3"
   },
   "devDependencies": {
-    "@remix-run/dev": "1.5.1",
-    "@remix-run/eslint-config": "1.5.1",
+    "@remix-run/dev": "*",
+    "@remix-run/eslint-config": "*",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",
-    "firebase-tools": "11.2.2",
+    "firebase-tools": "^11.21.0",
     "typescript": "^4.8.4"
   },
   "engines": {

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -10,9 +10,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/node": "*",
-    "@remix-run/react": "*",
-    "@remix-run/serve": "*",
+    "@remix-run/node": "1.5.1",
+    "@remix-run/react": "1.5.1",
+    "@remix-run/serve": "1.5.1",
     "firebase-admin": "^10.0.2",
     "firebase-functions": "^3.21.2",
     "isbot": "^3.6.5",
@@ -21,12 +21,12 @@
     "remix-google-cloud-functions": "0.0.1"
   },
   "devDependencies": {
-    "@remix-run/dev": "*",
-    "@remix-run/eslint-config": "*",
+    "@remix-run/dev": "1.5.1",
+    "@remix-run/eslint-config": "1.5.1",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",
-    "firebase-tools": "^11.0.1",
+    "firebase-tools": "11.2.2",
     "typescript": "^4.8.4"
   },
   "engines": {


### PR DESCRIPTION
## Various Fixes for Firebase example:

- Use node 16 in firebase example
  - An exact node version is needed in firebase/package.json as Firebase uses this to determine which version of node to use for the functions when you run `firebase deploy`. Setting this to 14 does not work, as this conflicts with the root .nvmrc (16). Setting to 14 will result in "Unsupported engine" errors from both yarn and npm install. This could be skipped using `yarn  --ignore-engines`, but I don't think that's a great experience for an example project. Previous discussion: https://github.com/remix-run/remix/pull/3398#discussion_r890170777
- Move hosting to port 5002 to avoid macOS port
  - https://developer.apple.com/forums/thread/682332
  - https://stackoverflow.com/questions/57537355/firebase-serve-error-port-5000-is-not-open-could-not-start-functions-emulator
- Update to remix-google-cloud-functions@0.0.3 for [compatability with remix@1.8.0](https://github.com/penx/remix-google-cloud-functions/commit/e1d896f78f67df1392ba6fea63980dc4ba1cb310)+
- Update to latest firebase-tools
