### PR TITLE
fix(image-resize): fix build error and warnings

### DIFF
--- a/image-resize/app/components/image.tsx
+++ b/image-resize/app/components/image.tsx
@@ -8,7 +8,7 @@ export interface ImageProps extends React.ComponentPropsWithRef<"img"> {
   fit?: keyof FitEnum; // contain is default
   alt: string;
 }
-const Image = forwardRef<HTMLImageElement, ImageProps>(
+export const Image = forwardRef<HTMLImageElement, ImageProps>(
   ({ children, width, height, fit, src, alt = "", ...other }, forwardedRef) => {
     const query = new URLSearchParams();
     if (width) {

--- a/image-resize/app/routes/assets/resize/$.ts
+++ b/image-resize/app/routes/assets/resize/$.ts
@@ -17,9 +17,10 @@ import { createReadStream, statSync } from "fs";
 import path from "path";
 import { PassThrough } from "stream";
 
-import type { LoaderArgs, Params } from "@remix-run/node";
+import type { LoaderArgs } from "@remix-run/node";
 import type { FitEnum } from "sharp";
 import sharp from "sharp";
+import type { Params } from "@remix-run/react";
 
 const ASSETS_ROOT = "assets";
 

--- a/image-resize/app/routes/index.tsx
+++ b/image-resize/app/routes/index.tsx
@@ -2,33 +2,33 @@ import { Image } from "~/components/image";
 
 const containerStyles = {
   padding: "2rem",
-  "margin-left": "auto",
-  "margin-right": "auto",
+  marginLeft: "auto",
+  marginRight: "auto",
 };
 const imageGridStyles = {
   display: "flex",
   gap: "1rem",
-  "align-items": "center",
-  "overflow-x": "scroll",
+  alignItems: "center",
+  overflowX: "scroll",
 };
 
 export default function Index() {
   return (
     <div style={containerStyles}>
       <h1>Cover</h1>
-      <div style={imageGridStyles}>
-        <Image src="dog-1.jpg" width={600} height={600} fit="cover" />
-        <Image src="dog-1.jpg" width={300} height={300} fit="cover" />
-        <Image src="dog-1.jpg" width={150} height={150} fit="cover" />
-        <Image src="dog-1.jpg" width={50} height={50} fit="cover" />
+      <div style={imageGridStyles as React.CSSProperties}>
+        <Image src="dog-1.jpg" alt="dog" width={600} height={600} fit="cover" />
+        <Image src="dog-1.jpg" alt="dog" width={300} height={300} fit="cover" />
+        <Image src="dog-1.jpg" alt="dog" width={150} height={150} fit="cover" />
+        <Image src="dog-1.jpg" alt="dog" width={50} height={50} fit="cover" />
       </div>
 
       <h1>Contain</h1>
-      <div style={imageGridStyles}>
-        <Image src="other-dogs/dog-2.jpg" width={600} fit="contain" />
-        <Image src="other-dogs/dog-2.jpg" width={300} fit="contain" />
-        <Image src="other-dogs/dog-2.jpg" width={150} fit="contain" />
-        <Image src="other-dogs/dog-2.jpg" width={50} fit="contain" />
+      <div style={imageGridStyles as React.CSSProperties}>
+        <Image src="other-dogs/dog-2.jpg" alt="dog" width={600} fit="contain" />
+        <Image src="other-dogs/dog-2.jpg" alt="dog" width={300} fit="contain" />
+        <Image src="other-dogs/dog-2.jpg" alt="dog" width={150} fit="contain" />
+        <Image src="other-dogs/dog-2.jpg" alt="dog" width={50} fit="contain" />
       </div>
     </div>
   );


### PR DESCRIPTION
Fix the following issues: 
Build failed with 1 error: No matching export in "app/components/image.tsx" for import "Image"
Warning: Unsupported style property margin-left, margin-right, align-items, overflow-x.
Property 'alt' is missing in type
Module '"@remix-run/node"' has no exported member 'Params'.