### PR TITLE
fix(_official_jokes): don't want to show unmoderated content

### DIFF
--- a/_official-jokes/app/routes/jokes[.]rss.tsx
+++ b/_official-jokes/app/routes/jokes[.]rss.tsx
@@ -1,13 +1,20 @@
 import type { LoaderArgs } from "@remix-run/node";
 
 import { db } from "~/utils/db.server";
+import { getUserId } from "~/utils/session.server";
 
 export const loader = async ({ request }: LoaderArgs) => {
-  const jokes = await db.joke.findMany({
-    take: 100,
-    orderBy: { createdAt: "desc" },
-    include: { jokester: { select: { username: true } } },
-  });
+  const userId = await getUserId(request);
+  const jokes = userId
+    ? await db.joke.findMany({
+        take: 100,
+        where: {
+          jokesterId: userId,
+        },
+        orderBy: { createdAt: "desc" },
+        include: { jokester: { select: { username: true } } },
+      })
+    : [];
 
   const host =
     request.headers.get("X-Forwarded-Host") ?? request.headers.get("host");


### PR DESCRIPTION
I found the jokes.rss could show others jokes, and the joke names could be unmoderated, so I thought I'd just fix it.  
Also fixed the get random joke functionality, it was using the count of all jokes to get random number for user's joke, which would usually be too big.