### PR TITLE
Bring chakra example root.tsx up-to-date with Remix 1.15

### DIFF
--- a/chakra-ui/app/root.tsx
+++ b/chakra-ui/app/root.tsx
@@ -1,5 +1,5 @@
 import { ChakraProvider, Box, Heading } from "@chakra-ui/react";
-import type { MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -7,13 +7,13 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  useCatch,
+  useRouteError,
 } from "@remix-run/react";
 
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  viewport: "width=device-width,initial-scale=1",
-});
+export const meta: V2_MetaFunction = () => [
+  { charset: "utf-8" },
+  { viewport: "width=device-width,initial-scale=1" },
+];
 
 function Document({
   children,
@@ -51,31 +51,15 @@ export default function App() {
   );
 }
 
-// How ChakraProvider should be used on CatchBoundary
-export function CatchBoundary() {
-  const caught = useCatch();
-
-  return (
-    <Document title={`${caught.status} ${caught.statusText}`}>
-      <ChakraProvider>
-        <Box>
-          <Heading as="h1" bg="purple.600">
-            [CatchBoundary]: {caught.status} {caught.statusText}
-          </Heading>
-        </Box>
-      </ChakraProvider>
-    </Document>
-  );
-}
-
 // How ChakraProvider should be used on ErrorBoundary
-export function ErrorBoundary({ error }: { error: Error }) {
+export function ErrorBoundary() {
+  const error = useRouteError();
   return (
     <Document title="Error!">
       <ChakraProvider>
         <Box>
           <Heading as="h1" bg="blue.500">
-            [ErrorBoundary]: There was an error: {error.message}
+            {`${error}`}
           </Heading>
         </Box>
       </ChakraProvider>


### PR DESCRIPTION
- Removes deprecated `CatchBoundary` in favor of `ErrorBoundary` and `useRouteError()`
- Uses new `V2_MetaFunction` format for meta fields