### PR TITLE
chore: use GitHub bot in `deduplicate-yarn` workflow

### DIFF
--- a/.github/workflows/deduplicate-yarn.yml
+++ b/.github/workflows/deduplicate-yarn.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: 💪 Commit
         run: |
-          git config --local user.email "hello@remix.run"
-          git config --local user.name "Remix Run Bot"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git add .
           if [ -z "$(git status --porcelain)" ]; then
             echo "💿 no deduplication needed"


### PR DESCRIPTION
We use it in the `format` workflow as well

https://github.com/remix-run/examples/blob/cff408e8841e8d6f24c3e4588e7f63985125ee4f/.github/workflows/format.yml#L43-L44