### PR TITLE
Update Node.js version in Docker examples

### DIFF
--- a/_official-blog-tutorial/Dockerfile
+++ b/_official-blog-tutorial/Dockerfile
@@ -1,5 +1,5 @@
 # base node image
-FROM node:16-bullseye-slim as base
+FROM node:18-bullseye-slim as base
 
 # set for base and all layer that inherit from it
 ENV NODE_ENV production

--- a/_official-jokes/Dockerfile
+++ b/_official-jokes/Dockerfile
@@ -1,5 +1,5 @@
 # base node image
-FROM node:16-bullseye-slim as base
+FROM node:18-bullseye-slim as base
 
 # Install openssl for Prisma
 RUN apt-get update && apt-get install -y openssl


### PR DESCRIPTION
Updates the Docker examples to use the current LTS version of Node.js. 

Node.js 16 will reach [end of life](https://nodejs.org/en/blog/announcements/nodejs16-eol) September 11, 2023.