### PR TITLE
fix(mantine): fix FOUC and handle error styles

### DIFF
--- a/mantine/app/clientStyleContext.tsx
+++ b/mantine/app/clientStyleContext.tsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+export const ClientStyleContext = createContext<{
+  reset: () => void;
+} | null>(null);

--- a/mantine/app/entry.client.tsx
+++ b/mantine/app/entry.client.tsx
@@ -1,15 +1,30 @@
-import { ClientProvider } from "@mantine/remix";
+import { CacheProvider } from "@emotion/react";
+import { createEmotionCache } from "@mantine/core";
 import { RemixBrowser } from "@remix-run/react";
-import { startTransition, StrictMode } from "react";
+import { startTransition, StrictMode, useState } from "react";
 import { hydrateRoot } from "react-dom/client";
+
+import { ClientStyleContext } from "./clientStyleContext";
+
+function ClientStyleProvider({ children }: { children: React.ReactNode }) {
+  const createCache = () => createEmotionCache({ key: "css" });
+  const [cache, setCache] = useState(createCache());
+  const reset = () => setCache(createCache());
+
+  return (
+    <ClientStyleContext.Provider value={{ reset }}>
+      <CacheProvider value={cache}>{children}</CacheProvider>
+    </ClientStyleContext.Provider>
+  );
+}
 
 startTransition(() => {
   hydrateRoot(
     document,
     <StrictMode>
-      <ClientProvider>
+      <ClientStyleProvider>
         <RemixBrowser />
-      </ClientProvider>
-    </StrictMode>,
+      </ClientStyleProvider>
+    </StrictMode>
   );
 });

--- a/mantine/app/root.tsx
+++ b/mantine/app/root.tsx
@@ -1,9 +1,14 @@
 import type { ColorScheme } from "@mantine/core";
 import {
-  MantineProvider,
+  Box,
   ColorSchemeProvider,
   createEmotionCache,
+  MantineProvider,
+  Title,
+  useEmotionCache,
 } from "@mantine/core";
+import { useIsomorphicEffect } from "@mantine/hooks";
+import { StylesPlaceholder } from "@mantine/remix";
 import type { MetaFunction } from "@remix-run/node";
 import {
   Links,
@@ -12,8 +17,11 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useCatch,
 } from "@remix-run/react";
-import { useState } from "react";
+import { useContext, useRef, useState } from "react";
+
+import { ClientStyleContext } from "./clientStyleContext";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
@@ -23,18 +31,86 @@ export const meta: MetaFunction = () => ({
 
 createEmotionCache({ key: "mantine" });
 
+export function CatchBoundary() {
+  const caught = useCatch();
+
+  return (
+    <Document title={`${caught.status} ${caught.statusText}`}>
+      <Box p="lg">
+        <Title color="red">
+          [CatchBoundary]: {caught.status} {caught.statusText}
+        </Title>
+      </Box>
+    </Document>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: Error }) {
+  return (
+    <Document title="Error!">
+      <Box p="lg">
+        <Title color="red">
+          [ErrorBoundary]: There was an error: {error.message}
+        </Title>
+      </Box>
+    </Document>
+  );
+}
+
 export default function App() {
+  return (
+    <Document>
+      <Outlet />
+    </Document>
+  );
+}
+
+function Document({
+  title,
+  children,
+}: {
+  title?: string;
+  children: React.ReactNode;
+}) {
+  const clientStyleData = useContext(ClientStyleContext);
+  const cache = useEmotionCache();
+  const reinjectStylesRef = useRef(true);
+
+  // Only executed on client
+  // When a top level ErrorBoundary or CatchBoundary are rendered,
+  // the document head gets removed, so we have to create the style tags
+  useIsomorphicEffect(() => {
+    if (!reinjectStylesRef.current) {
+      return;
+    }
+
+    // re-link sheet container
+    cache.sheet.container = document.head;
+
+    // re-inject tags
+    const tags = cache.sheet.tags;
+    cache.sheet.flush();
+    tags.forEach((tag) => {
+      (cache.sheet as any)._insertTag(tag);
+    });
+
+    // reset cache to re-apply global styles
+    clientStyleData?.reset();
+
+    // ensure we only do this once per mount
+    reinjectStylesRef.current = false;
+  }, []);
+
   return (
     <html lang="en">
       <head>
+        <StylesPlaceholder />
+        {title ? <title>{title}</title> : null}
         <Meta />
         <Links />
       </head>
       <body>
-        <MantineTheme>
-          <Outlet />
-        </MantineTheme>
-
+        <MantineTheme>{children}</MantineTheme>
         <ScrollRestoration />
         <Scripts />
         <LiveReload />

--- a/mantine/app/routes/error.tsx
+++ b/mantine/app/routes/error.tsx
@@ -1,0 +1,3 @@
+export default function ErrorRoute() {
+  throw new Error("This route throws on render!");
+}

--- a/mantine/app/routes/index.tsx
+++ b/mantine/app/routes/index.tsx
@@ -1,14 +1,37 @@
-import { Switch, useMantineColorScheme } from "@mantine/core";
+import {
+  List,
+  Stack,
+  Switch,
+  Text,
+  Title,
+  useMantineColorScheme,
+} from "@mantine/core";
+import { Link } from "@remix-run/react";
 
 export default function Index() {
   const { colorScheme, toggleColorScheme } = useMantineColorScheme();
   const dark = colorScheme === "dark";
 
   return (
-    <Switch
-      color={dark ? "yellow" : "blue"}
-      label="Dark theme"
-      onClick={() => toggleColorScheme()}
-    />
+    <Stack spacing="md" p="lg">
+      <Title>Welcome to Remix with Mantine Example</Title>
+      <Switch
+        color={dark ? "yellow" : "blue"}
+        label="Dark theme"
+        onClick={() => toggleColorScheme()}
+      />
+      <List>
+        <List.Item>
+          <Text>
+            <Link to="/error">Error page</Link>
+          </Text>
+        </List.Item>
+        <List.Item>
+          <Text>
+            <Link to="/404">404 page</Link>
+          </Text>
+        </List.Item>
+      </List>
+    </Stack>
   );
 }


### PR DESCRIPTION
This fixes a couple of issues with the Mantine example:
- There was a flash of unstyled content on load due to missing `<StylesPlaceholder />`.
- The styles were removed from the document when navigating between error routes and non-error routes. This is due to the way in which Remix re-renders the entire document from the root when rendering a root-level error component. The fix is based on [correiarmjoao/remix-with-mantine](https://github.com/correiarmjoao/remix-with-mantine) by @correiarmjoao (shared in https://github.com/remix-run/remix/issues/1136).