### PR TITLE
fix(tailwind): update to required Remix version

### DIFF
--- a/tailwindcss/app/root.tsx
+++ b/tailwindcss/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -14,16 +14,12 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
-
 export default function App() {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/tailwindcss/app/routes/_index.tsx
+++ b/tailwindcss/app/routes/_index.tsx
@@ -1,0 +1,7 @@
+import type { V2_MetaFunction } from "@remix-run/node";
+
+export const meta: V2_MetaFunction = () => [{ title: "New Remix App" }];
+
+export default function Index() {
+  return <h1 className="text-6xl font-bold text-red-700">Hello World!</h1>;
+}

--- a/tailwindcss/app/routes/index.tsx
+++ b/tailwindcss/app/routes/index.tsx
@@ -1,3 +1,0 @@
-export default function Index() {
-  return <h1 className="text-6xl font-bold text-red-700">Hello World!</h1>;
-}

--- a/tailwindcss/package.json
+++ b/tailwindcss/package.json
@@ -8,16 +8,16 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/node": "~1.14.2",
-    "@remix-run/react": "~1.14.2",
-    "@remix-run/serve": "~1.14.2",
+    "@remix-run/node": "~1.16.0",
+    "@remix-run/react": "~1.16.0",
+    "@remix-run/serve": "~1.16.0",
     "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "~1.14.2",
-    "@remix-run/eslint-config": "~1.14.2",
+    "@remix-run/dev": "~1.16.0",
+    "@remix-run/eslint-config": "~1.16.0",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",

--- a/tailwindcss/remix.config.js
+++ b/tailwindcss/remix.config.js
@@ -1,5 +1,11 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
+  future: {
+    v2_errorBoundary: true,
+    v2_meta: true,
+    v2_normalizeFormMethod: true,
+    v2_routeConvention: true,
+  },
   ignoredRouteFiles: ["**/.*"],
   tailwind: true,
   // appDirectory: "app",


### PR DESCRIPTION
Fixes https://github.com/remix-run/remix/issues/7076

The Tailwind example is pinned to Remix v1.14.x which doesn't support the `tailwind: true` flag, so this example is currently broken due to missing styles. I've updated the example to the same versioning scheme but targeting the minimum required range of `1.16.x`.

To minimise deprecation warnings in the terminal, I've opted into the same set of feature flags used in the tutorial examples.