### PR TITLE
Update useMatchesData return type

### DIFF
--- a/usematches-loader-data/app/useMatchesData.ts
+++ b/usematches-loader-data/app/useMatchesData.ts
@@ -15,5 +15,5 @@ export function useMatchesData(
     () => matchingRoutes.find((route) => route.id === id),
     [matchingRoutes, id],
   );
-  return route?.data;
+  return route?.data as Record<string, unknown>;
 }


### PR DESCRIPTION
I was upgrading from Remix v1 to v2 and noticed this had been updated in `remix-run/blues-stack` but not here in the examples.

This change now matches this example repo [to the blues-stack repo](https://github.com/remix-run/blues-stack/blob/main/app/utils.ts#L44).