### PR TITLE
Convert MSW example to use TS files

### DIFF
--- a/msw/README.md
+++ b/msw/README.md
@@ -21,8 +21,8 @@ You can read more about the use cases of MSW [here](https://mswjs.io/docs/#when-
 
 ## Relevant files
 
-- [mocks](./mocks/index.cjs) - registers the Node HTTP mock server
-- [handlers](./mocks/handlers.cjs) - describes the HTTP mocks
+- [mocks](./mocks/index.ts) - registers the Node HTTP mock server
+- [handlers](./mocks/handlers.ts) - describes the HTTP mocks
 - [package.json](./package.json)
 
 ## Related Links

--- a/msw/mocks/handlers.cjs
+++ b/msw/mocks/handlers.cjs
@@ -1,9 +1,0 @@
-const { http, HttpResponse } = require("msw");
-
-const handlers = [
-  http.get("https://my-mock-api.com", () => {
-    return HttpResponse.json({ message: "from msw" });
-  }),
-];
-
-module.exports = handlers;

--- a/msw/mocks/handlers.ts
+++ b/msw/mocks/handlers.ts
@@ -1,0 +1,8 @@
+import type { HttpHandler }  from "msw";
+import { http, HttpResponse }  from "msw";
+
+export const handlers = [
+  http.get("https://my-mock-api.com", () => {
+    return HttpResponse.json({ message: "from msw" });
+  }),
+] satisfies HttpHandler[];

--- a/msw/mocks/index.ts
+++ b/msw/mocks/index.ts
@@ -1,6 +1,5 @@
-const { setupServer } = require("msw/node");
-
-const handlers = require("./handlers.cjs");
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers.js";
 
 const server = setupServer(...handlers);
 server.listen({ onUnhandledRequest: "warn" });

--- a/msw/package.json
+++ b/msw/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "remix vite:build",
-    "dev": "binode --require ./mocks/index.cjs -- @remix-run/dev:remix vite:dev",
+    "dev": "binode --import=tsx --import ./mocks/index.ts -- @remix-run/dev:remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "remix-serve ./build/server/index.js",
     "typecheck": "tsc"
@@ -32,6 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "msw": "^2.3",
+    "tsx": "^4.19.1",
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1"


### PR DESCRIPTION
As discussed here: https://github.com/remix-run/examples/pull/494#issuecomment-2367436968

This updates the MSW example so the MSW files are written in TypeScript for better type safety when writing mocks.